### PR TITLE
Select filesystem in platformio.ini

### DIFF
--- a/src/rtc_memory.cpp
+++ b/src/rtc_memory.cpp
@@ -21,12 +21,14 @@
 
 // Select (uncomment) ONLY ONE file system
 //(NOTE: SPIFFS is deprecated but working)
-#define ESP_LOGGER_FLASH_FS_SPIFFS
-//#define ESP_LOGGER_FLASH_FS_LITTLEFS
+#if !defined(ESP_LOGGER_FLASH_FS_USE_LITTLEFS) && !defined(ESP_LOGGER_FLASH_FS_USE_SPIFFS)
+#define ESP_LOGGER_FLASH_FS_USE_SPIFFS
+// #define ESP_LOGGER_FLASH_FS_USE_LITTLEFS
+#endif
 
-#ifdef ESP_LOGGER_FLASH_FS_SPIFFS
+#if defined(ESP_LOGGER_FLASH_FS_USE_SPIFFS)
 #define ESP_LOGGER_FLASH_FS SPIFFS
-#elif defined(ESP_LOGGER_FLASH_FS_LITTLEFS)
+#elif defined(ESP_LOGGER_FLASH_FS_USE_LITTLEFS)
 #define ESP_LOGGER_FLASH_FS LittleFS
 #include <LittleFS.h>
 #endif


### PR DESCRIPTION
Allow selecting the filesystem by using -D ESP_LOGGER_FLASH_FS_USE_LITTLEFS or -D ESP_LOGGER_FLASH_FS_USE_SPIFFS in platfomio.ini without having to change the rtc_memory.cpp file. This will not impact using the library with the Arduino IDE.